### PR TITLE
Added sql, plsql and shellscript support.

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -23,7 +23,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 	let findSingleLineComments = function () {
 		// Regex will find: // + ! OR ? OR // OR TODO, until end of line
-		const regEx = /(\/\/|\#|\-\-)+( )?(\!|\?|(\/\/|\#|\-\-)|\*|(todo))+(.*)+/ig;
+		const regEx = /(\/\/|\#|\-\-)+( )?(\!|\?|(\/\/)|\*|(todo))+(.*)+/ig;
 		const text = activeEditor.document.getText();
 
 		let match;
@@ -43,8 +43,6 @@ export function activate(context: vscode.ExtensionContext) {
 					break;
 
 				case "//":
-				case "#":
-				case "--":
 					removed.push(decoration);
 					break;
 

--- a/extension.ts
+++ b/extension.ts
@@ -23,7 +23,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 	let findSingleLineComments = function () {
 		// Regex will find: // + ! OR ? OR // OR TODO, until end of line
-		const regEx = /(\/\/)+( )?(\!|\?|\/\/|\*|(todo))+(.*)+/ig;
+		const regEx = /(\/\/|\#|\-\-)+( )?(\!|\?|(\/\/|\#|\-\-)|\*|(todo))+(.*)+/ig;
 		const text = activeEditor.document.getText();
 
 		let match;
@@ -43,6 +43,8 @@ export function activate(context: vscode.ExtensionContext) {
 					break;
 
 				case "//":
+				case "#":
+				case "--":
 					removed.push(decoration);
 					break;
 

--- a/extension.ts
+++ b/extension.ts
@@ -23,7 +23,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 	let findSingleLineComments = function () {
 		// Regex will find: // + ! OR ? OR // OR TODO, until end of line
-		const regEx = /(\/\/|\#|\-\-)+( )?(\!|\?|(\/\/)|\*|(todo))+(.*)+/ig;
+		const regEx = /(\/\/|\#|\-\-)+( )?(\!|\?|\/\/|\*|(todo))+(.*)+/ig;
 		const text = activeEditor.document.getText();
 
 		let match;

--- a/package.json
+++ b/package.json
@@ -33,7 +33,10 @@
         "onLanguage:lua",
         "onLanguage:php",
         "onLanguage:rust",
-        "onLanguage:typescript"
+        "onLanguage:typescript",
+        "onLanguage:shellscript",
+        "onLanguage:plsql",
+        "onLanguage:sql"
     ],
     "galleryBanner": {
         "color": "#e3f4ff",


### PR DESCRIPTION
Just added the '#' from bash and '--' from PL/SQL to the matching regex for single line comments.

Multi-line comments aren't a thing in bash and /* */ will work in PL/SQL already.