### PR TITLE
Add support for COBOL inline comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The default 5 can be modifed to change the colors, and more can be added.
 * CSS
 * C++
 * C#
+* COBOL
 * Dockerfile
 * Elixir
 * Erlang

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "onLanguage:cpp",
         "onLanguage:csharp",
         "onLanguage:css",
+	"onLanguage:cobol",
         "onLanguage:elixir",
         "onLanguage:erlang",
         "onLanguage:fsharp",

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -206,6 +206,8 @@ export class Parser {
 			case "erlang":
 			case "latex":
 				this.delimiter = "%";
+			case "COBOL":
+				this.delimiter = "*>";
 		}
 	}
 


### PR DESCRIPTION
Simply adding comment delimiter "*>" to language ID "COBOL" in the parser.