### PR TITLE
Add support for Dart language

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The default 5 can be modifed to change the colors, and more can be added.
 * CSS
 * C++
 * C#
+* Dart
 * Dockerfile
 * Elixir
 * Erlang

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "better-comments",
-    "version": "1.2.3",
+    "version": "1.1.8",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "better-comments",
-    "version": "1.1.8",
+    "version": "1.2.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "onLanguage:cpp",
         "onLanguage:csharp",
         "onLanguage:css",
+        "onLanguage:dart",
         "onLanguage:dockerfile",
         "onLanguage:elixir",
         "onLanguage:erlang",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "Better Comments",
     "icon": "icon.png",
     "description": "Improve your code commenting by annotating with alert, informational, TODOs, and more!",
-    "version": "1.2.3",
+    "version": "1.2.2",
     "publisher": "aaron-bond",
     "author": {
         "name": "Aaron Bond"
@@ -30,7 +30,6 @@
         "onLanguage:cpp",
         "onLanguage:csharp",
         "onLanguage:css",
-        "onLanguage:dart",
         "onLanguage:dockerfile",
         "onLanguage:elixir",
         "onLanguage:erlang",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "Better Comments",
     "icon": "icon.png",
     "description": "Improve your code commenting by annotating with alert, informational, TODOs, and more!",
-    "version": "1.2.2",
+    "version": "1.2.3",
     "publisher": "aaron-bond",
     "author": {
         "name": "Aaron Bond"
@@ -30,6 +30,7 @@
         "onLanguage:cpp",
         "onLanguage:csharp",
         "onLanguage:css",
+        "onLanguage:dart",
         "onLanguage:dockerfile",
         "onLanguage:elixir",
         "onLanguage:erlang",

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -20,7 +20,7 @@ interface Contributions {
 export class Parser {
 	private tags: CommentTag[] = [];
 	private expression: string = "";
-	private delimiters: string[] = [""];
+	private delimiters: string[] = [];
 	private highlightMultilineComments = false;
 
 	// * this is used to trigger the events when a supported language code is found
@@ -46,18 +46,10 @@ export class Parser {
 			characters.push(commentTag.escapedTag);
 		}
 
-		// start by finding the delimiter (//, --, #, ') with optional spaces or tabs
+		// start by finding the delimiter (//, ///, --, #, ') with optional spaces or tabs
 		this.expression = "(";
-		this.delimiters.forEach(element => {
-			this.expression += element.replace(/\//ig, "\\/");
-			if (this.delimiters.lastIndexOf(element) != this.delimiters.length - 1) {
-				this.expression += "|";
-			} else {
-				this.expression += ")";
-			}
-
-		});
-		this.expression += "+( |\t)*";
+		this.expression += this.delimiters.join("|").replace(/\//ig, "\\/");
+		this.expression += ")+( |\t)*";
 
 		// Apply all configurable comment start tags
 		this.expression += "("
@@ -167,8 +159,11 @@ export class Parser {
 	 */
 	private setDelimiter(languageCode: string): void {
 		this.supportedLanguage = true;
+		this.delimiters = [];
 
 		switch (languageCode) {
+			case "dart":
+				this.delimiters.push("///");
 			case "al":
 			case "c":
 			case "cpp":
@@ -191,12 +186,7 @@ export class Parser {
 			case "swift":
 			case "typescript":
 			case "typescriptreact":
-				this.delimiters = ["//"];
-				this.highlightMultilineComments = this.contributions.multilineComments;
-				break;
-
-			case "dart":
-				this.delimiters = ["///", "//"];
+				this.delimiters.push("//");
 				this.highlightMultilineComments = this.contributions.multilineComments;
 				break;
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -159,11 +159,8 @@ export class Parser {
 	 */
 	private setDelimiter(languageCode: string): void {
 		this.supportedLanguage = true;
-		this.delimiters = [];
 
 		switch (languageCode) {
-			case "dart":
-				this.delimiters.push("///");
 			case "al":
 			case "c":
 			case "cpp":
@@ -186,7 +183,12 @@ export class Parser {
 			case "swift":
 			case "typescript":
 			case "typescriptreact":
-				this.delimiters.push("//");
+				this.delimiters = ["//"];
+				this.highlightMultilineComments = this.contributions.multilineComments;
+				break;
+
+			case "dart":
+				this.delimiters = ["///", "//"];
 				this.highlightMultilineComments = this.contributions.multilineComments;
 				break;
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -20,7 +20,7 @@ interface Contributions {
 export class Parser {
 	private tags: CommentTag[] = [];
 	private expression: string = "";
-	private delimiter: string = "";
+	private delimiters: string[] = [""];
 	private highlightMultilineComments = false;
 
 	// * this is used to trigger the events when a supported language code is found
@@ -47,7 +47,17 @@ export class Parser {
 		}
 
 		// start by finding the delimiter (//, --, #, ') with optional spaces or tabs
-		this.expression = "(" + this.delimiter.replace(/\//ig, "\\/") + ")+( |\t)*";
+		this.expression = "(";
+		this.delimiters.forEach(element => {
+			this.expression += element.replace(/\//ig, "\\/");
+			if (this.delimiters.lastIndexOf(element) != this.delimiters.length - 1) {
+				this.expression += "|";
+			} else {
+				this.expression += ")";
+			}
+
+		});
+		this.expression += "+( |\t)*";
 
 		// Apply all configurable comment start tags
 		this.expression += "("
@@ -157,7 +167,7 @@ export class Parser {
 	 */
 	private setDelimiter(languageCode: string): void {
 		this.supportedLanguage = true;
-		
+
 		switch (languageCode) {
 			case "al":
 			case "c":
@@ -181,7 +191,12 @@ export class Parser {
 			case "swift":
 			case "typescript":
 			case "typescriptreact":
-				this.delimiter = "//";
+				this.delimiters = ["//"];
+				this.highlightMultilineComments = this.contributions.multilineComments;
+				break;
+
+			case "dart":
+				this.delimiters = ["///", "//"];
 				this.highlightMultilineComments = this.contributions.multilineComments;
 				break;
 
@@ -199,7 +214,7 @@ export class Parser {
 			case "ruby":
 			case "shellscript":
 			case "yaml":
-				this.delimiter = "#";
+				this.delimiters = ["#"];
 				break;
 
 			case "ada":
@@ -207,26 +222,26 @@ export class Parser {
 			case "plsql":
 			case "sql":
 			case "lua":
-				this.delimiter = "--";
+				this.delimiters = ["--"];
 				break;
 
 			case "vb":
-				this.delimiter = "'";
+				this.delimiters = ["'"];
 				break;
 
 			case "erlang":
 			case "latex":
-				this.delimiter = "%";
+				this.delimiters = ["%"];
 				break;
 
 			case "clojure":
 			case "racket":
 			case "lisp":
-				this.delimiter = ";";
+				this.delimiters = [";"];
 				break;
-			
+
 			case "terraform":
-				this.delimiter = "#";
+				this.delimiters = ["#"];
 				this.highlightMultilineComments = this.contributions.multilineComments;
 				break;
 


### PR DESCRIPTION
Hey, 

this PR adds support for [Dart language](https://www.dartlang.org/). It also includes support for Dart's doc comment syntax `///`.

 I'd appreciate any feedback and I'd love to help out more with this great extension.