### PR TITLE
Add Nim single-line comment support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ The default 5 can be modifed to change the colors, and more can be added.
 * Lua
 * Makefile
 * MATLAB
+* Nim
 * Objective-C
 * Objective-C++
 * Pascal

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -197,6 +197,7 @@ export class Parser {
 			case "graphql":
 			case "julia":
 			case "makefile":
+			case "nim":
 			case "perl":
 			case "perl6":
 			case "powershell":
@@ -204,7 +205,6 @@ export class Parser {
 			case "ruby":
 			case "shellscript":
 			case "yaml":
-			case "nim":
 				this.delimiter = "#";
 				break;
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -204,6 +204,7 @@ export class Parser {
 			case "ruby":
 			case "shellscript":
 			case "yaml":
+			case "nim":
 				this.delimiter = "#";
 				break;
 


### PR DESCRIPTION
Nim comments use '#' for single line comments. There are a few multi-line options once multi-line custom support is added. https://nim-lang.org/docs/tut1.html#lexical-elements-comments