### PR TITLE
update readme settings for JSON semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,40 +27,39 @@ When true, the tags (defaults: `! * ? //`) will be detected if they're the first
 `better-comments.tags`  
 The tags are the characters or sequences used to mark a comment for decoration.
 The default 5 can be modifed to change the colors, and more can be added.
-  `strikethrough`: true,
 ```json
 "better-comments.tags": [
-    {
-      "tag": "!",
-      "color": "#FF2D00",
-      "strikethrough": false,
-      "backgroundColor": "transparent"
-    },
-    {
-      "tag": "?",
-      "color": "#3498DB",
-      "strikethrough": false,
-      "backgroundColor": "transparent"
-    },
-    {
-      "tag": "//",
-      "color": "#474747",
-      "strikethrough": true,
-      "backgroundColor": "transparent"
-    },
-    {
-      "tag": "todo",
-      "color": "#FF8C00",
-      "strikethrough": false,
-      "backgroundColor": "transparent"
-    },
-    {
-      "tag": "*",
-      "color": "#98C379",
-      "strikethrough": false,
-      "backgroundColor": "transparent"
-    }
-  ]
+  {
+    "tag": "!",
+    "color": "#FF2D00",
+    "strikethrough": false,
+    "backgroundColor": "transparent"
+  },
+  {
+    "tag": "?",
+    "color": "#3498DB",
+    "strikethrough": false,
+    "backgroundColor": "transparent"
+  },
+  {
+    "tag": "//",
+    "color": "#474747",
+    "strikethrough": true,
+    "backgroundColor": "transparent"
+  },
+  {
+    "tag": "todo",
+    "color": "#FF8C00",
+    "strikethrough": false,
+    "backgroundColor": "transparent"
+  },
+  {
+    "tag": "*",
+    "color": "#98C379",
+    "strikethrough": false,
+    "backgroundColor": "transparent"
+  }
+]
 ```
 
 ## Supported Languages

--- a/README.md
+++ b/README.md
@@ -16,44 +16,51 @@ With this extension, you will be able to categorise your annotations into:
 This extension can be configured in User Settings or Workspace settings.
 
 
-`'better-comments.multilineComments': true`  
+`"better-comments.multilineComments": true`  
  This setting will control whether multiline comments are styled using the annotation tags.
  When false, multiline comments will be presented without decoration.
 
-`'better-comments.highlightPlainText': false`  
+`"better-comments.highlightPlainText": false`  
 This setting will control whether comments in a plain text file are styled using the annotation tags.
 When true, the tags (defaults: `! * ? //`) will be detected if they're the first character on a line.
 
 `better-comments.tags`  
 The tags are the characters or sequences used to mark a comment for decoration.
 The default 5 can be modifed to change the colors, and more can be added.
-```javascript
-[{
-  `tag`: '!',
-  `color`: '#FF2D00',
-  `strikethrough`: false,
-  `backgroundColor`: 'transparent'
-},{
-  `tag`: '?',
-  `color`: '#3498DB',
-  `strikethrough`: false,
-  `backgroundColor`: 'transparent'
-},{
-  `tag`: '//',
-  `color`: '#474747',
   `strikethrough`: true,
-  `backgroundColor`: 'transparent'
-},{
-  `tag`: 'todo',
-  `color`: '#FF8C00',
-  `strikethrough`: false,
-  `backgroundColor`: 'transparent'
-},{
-  `tag`: '*',
-  `color`: '#98C379',
-  `strikethrough`: false,
-  `backgroundColor`: 'transparent'
-}]
+```json
+"better-comments.tags": [
+    {
+      "tag": "!",
+      "color": "#FF2D00",
+      "strikethrough": false,
+      "backgroundColor": "transparent"
+    },
+    {
+      "tag": "?",
+      "color": "#3498DB",
+      "strikethrough": false,
+      "backgroundColor": "transparent"
+    },
+    {
+      "tag": "//",
+      "color": "#474747",
+      "strikethrough": true,
+      "backgroundColor": "transparent"
+    },
+    {
+      "tag": "todo",
+      "color": "#FF8C00",
+      "strikethrough": false,
+      "backgroundColor": "transparent"
+    },
+    {
+      "tag": "*",
+      "color": "#98C379",
+      "strikethrough": false,
+      "backgroundColor": "transparent"
+    }
+  ]
 ```
 
 ## Supported Languages


### PR DESCRIPTION
The settings in the current readme.md are semantically incorrect when pasting into VS Code. Updated to correct JSON semantics.