### PR TITLE
Add support for PlantUML standalone files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ The default 5 can be modifed to change the colors, and more can be added.
 * Perl 6
 * PHP
 * Pig
+* PlantUML
 * PL/SQL
 * PowerShell
 * Python

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
         "onLanguage:perl6",
         "onLanguage:pig",
         "onLanguage:plaintext",
+        "onLanguage:diagram",
         "onLanguage:plsql",
         "onLanguage:php",
         "onLanguage:powershell",

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -251,6 +251,7 @@ export class Parser {
 				break;
 
 			case "vb":
+			case "diagram": // ? PlantUML is recognized as Diagram (diagram)
 				this.delimiter = "'";
 				break;
 


### PR DESCRIPTION
Included case label for 'diagram' language, as vscode recognizes it.

A minor change, and from a not so expert (I saw the other PRs and checked where was kind of logic to make the modifications). If something else is needed, happy to help (and learn).