### PR TITLE
[TASK] add fluid comment viewhelper support for html files

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -366,6 +366,7 @@ export class Parser {
 			
 			case "html":
 				this.setCommentFormat("<!--", "<!--", "-->");
+				this.setCommentFormat(null, "<f:comment>", "</f:comment>");
 				break;
 			
 			case "twig":


### PR DESCRIPTION
I add fluid viewhelper support for TYPO3 programmers
the fluid viewhelper is the pendant to the <!-- --> html comments

the difference is this comment doesn't shows up in the source code