### PR TITLE
Added "CFML" (ColdFusion Markup Language)

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -257,6 +257,7 @@ export class Parser {
 
 			case "al":
 			case "c":
+			case "cfml":
 			case "cpp":
 			case "csharp":
 			case "dart":


### PR DESCRIPTION
Adds support for parsing CFML language files for JSDoc comments.
Side note: this should work with CFML written in CFScript, but not CFTags as they use different comment notation.
CFScript comments can look like this /* block comment */ or // line comment
CFTag comments can look like this <!--- block comment --->
It doesn't look like setCommentFormat() supports multiple types of comments.