### PR TITLE
Allow fixed format COBOL comments to be picked up

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -363,7 +363,7 @@ export class Parser {
 				break;
 
 			case "COBOL":
-				this.delimiter = this.escapeRegExp("*>");
+				this.delimiter = "[0-9 ][0-9 ][0-9 ][0-9 ][0-9 ][0-9 ]"+this.escapeRegExp("*")+"|"+this.escapeRegExp("*>")
 				break;
 
 			case "fortran-modern":


### PR DESCRIPTION
COBOL has another comment and this is the fixed format comment, which is basically a *
in column 7 (indicator area)


