### PR TITLE
Add Dhall support

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The default 5 can be modifed to change the colors, and more can be added.
 * CoffeeScript
 * CSS
 * Dart
+* Dhall
 * Dockerfile
 * Elixir
 * Elm

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "onLanguage:css",
         "onLanguage:d",
         "onLanguage:dart",
+        "onLanguage:dhall",
         "onLanguage:diagram",
         "onLanguage:dockerfile",
         "onLanguage:elixir",

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -335,6 +335,7 @@ export class Parser {
 				this.setCommentFormat("--", "--[[", "]]");
 				break;
 
+			case "dhall":
 			case "elm":
 			case "haskell":
 				this.setCommentFormat("--", "{-", "-}");

--- a/src/test/samples/dhall.dhall
+++ b/src/test/samples/dhall.dhall
@@ -1,0 +1,13 @@
+{- 
+   ! Don't repeat yourself!
+
+   Repetition is error-prone
+-}
+
+let user = "bill"
+in  { home       = "/home/${user}"
+    , privateKey = "/home/${user}/.ssh/id_ed25519"
+    , publicKey  = "/home/${user}/.ssh/id_ed25519.pub"
+    }
+
+-- TODO Change the name "bill" to "jane"


### PR DESCRIPTION
Add support for the [Dhall programmable configuration language](https://dhall-lang.org/).  Since its comment syntax is identical to Haskell/Elm, this is an extremely minor patch.