### PR TITLE
Adding TableGen support

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ The default 5 can be modifed to change the colors, and more can be added.
 * STATA
 * Stylus
 * Swift
+* TableGen
 * Tcl
 * Terraform
 * Twig

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
         "onLanguage:stata",
         "onLanguage:stylus",
         "onLanguage:swift",
+        "onLanguage:tablegen",
         "onLanguage:tcl",
         "onLanguage:terraform",
         "onLanguage:twig",

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -278,6 +278,7 @@ export class Parser {
 			case "scss":
 			case "stylus":
 			case "swift":
+			case "tablegen":
 			case "verilog":
 			case "vue":
 				this.setCommentFormat("//", "/*", "*/");


### PR DESCRIPTION
The _tablegen_ language is part of the [llvm project](https://github.com/llvm/llvm-project). Its comment style is derived from the C++ one.
Please do note that the _tablegen_ language is not natively supported by _vscode_ but support is provided via [this extension](https://marketplace.visualstudio.com/items?itemName=jakob-erzar.llvm-tablegen).