### PR TITLE
FEAT - add underline/bold/italic to tags

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -15,6 +15,9 @@ interface Contributions {
 		tag: string;
 		color: string;
 		strikethrough: boolean;
+		underline: boolean;
+		bold: boolean;
+		italic: boolean;
 		backgroundColor: string;
 	}];
 }
@@ -414,6 +417,15 @@ export class Parser {
 			let options: vscode.DecorationRenderOptions = { color: item.color, backgroundColor: item.backgroundColor };
 			if (item.strikethrough) {
 				options.textDecoration = "line-through";
+			} else if (item.underline) {
+				options.textDecoration = "underline";
+			}
+			
+			if(item.bold) {
+				options.fontWeight = "bold";
+			}
+			if(item.italic) {
+				options.fontStyle = "italic";
 			}
 
 			let escapedSequence = item.tag.replace(/([()[{*+.$^\\|?])/g, '\\$1');


### PR DESCRIPTION
### In response to https://github.com/aaron-bond/better-comments/issues/50

- add them as boolean
- fontWeight not added because [fontWeight](https://vshaxe.github.io/vscode-extern/vscode/DecorationRenderOptions.html#fontWeight) accepts a string while the css doc await for a number. I don't want to include misleading options (property could be "bold", "700" but not 700) , better to keep a boolean than introduce complicated usage.
- fontFamily and fontSize not availables in VSCode doc