### PR TITLE
FEAT/FIX - bold/italic/underline + fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,11 @@ os: linux
 language: node_js
 node_js: '8.9.2'
 
+services:
+  - xvfb
+
 before_install:
 - export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0;
-- sh -e /etc/init.d/xvfb start;
 
 install:
 - npm install

--- a/README.md
+++ b/README.md
@@ -33,31 +33,46 @@ The default 5 can be modifed to change the colors, and more can be added.
     "tag": "!",
     "color": "#FF2D00",
     "strikethrough": false,
-    "backgroundColor": "transparent"
+    "backgroundColor": "transparent",
+    "bold": false,
+    "italic": false,
+    "underline": false
   },
   {
     "tag": "?",
     "color": "#3498DB",
     "strikethrough": false,
-    "backgroundColor": "transparent"
+    "backgroundColor": "transparent",
+    "bold": false,
+    "italic": false,
+    "underline": false
   },
   {
     "tag": "//",
     "color": "#474747",
     "strikethrough": true,
-    "backgroundColor": "transparent"
+    "backgroundColor": "transparent",
+    "bold": false,
+    "italic": false,
+    "underline": false
   },
   {
     "tag": "todo",
     "color": "#FF8C00",
     "strikethrough": false,
-    "backgroundColor": "transparent"
+    "backgroundColor": "transparent",
+    "bold": false,
+    "italic": false,
+    "underline": false
   },
   {
     "tag": "*",
     "color": "#98C379",
     "strikethrough": false,
-    "backgroundColor": "transparent"
+    "backgroundColor": "transparent",
+    "bold": false,
+    "italic": false,
+    "underline": false
   }
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -27,52 +27,55 @@ When true, the tags (defaults: `! * ? //`) will be detected if they're the first
 `better-comments.tags`  
 The tags are the characters or sequences used to mark a comment for decoration.
 The default 5 can be modifed to change the colors, and more can be added.
+
+**strikethrough and underline are mutually exclusive, only one of them can be applied**
+
 ```json
 "better-comments.tags": [
   {
     "tag": "!",
     "color": "#FF2D00",
     "strikethrough": false,
+    "underline": false,
     "backgroundColor": "transparent",
     "bold": false,
-    "italic": false,
-    "underline": false
+    "italic": false
   },
   {
     "tag": "?",
     "color": "#3498DB",
     "strikethrough": false,
+    "underline": false,
     "backgroundColor": "transparent",
     "bold": false,
-    "italic": false,
-    "underline": false
+    "italic": false
   },
   {
     "tag": "//",
     "color": "#474747",
     "strikethrough": true,
+    "underline": false,
     "backgroundColor": "transparent",
     "bold": false,
-    "italic": false,
-    "underline": false
+    "italic": false
   },
   {
     "tag": "todo",
     "color": "#FF8C00",
     "strikethrough": false,
+    "underline": false,
     "backgroundColor": "transparent",
     "bold": false,
-    "italic": false,
-    "underline": false
+    "italic": false
   },
   {
     "tag": "*",
     "color": "#98C379",
     "strikethrough": false,
+    "underline": false,
     "backgroundColor": "transparent",
     "bold": false,
-    "italic": false,
-    "underline": false
+    "italic": false
   }
 ]
 ```

--- a/package.json
+++ b/package.json
@@ -140,31 +140,46 @@
                             "tag": "!",
                             "color": "#FF2D00",
                             "strikethrough": false,
-                            "backgroundColor": "transparent"
+                            "backgroundColor": "transparent",
+                            "bold": false,
+                            "italic": false,
+                            "underline": false
                         },
                         {
                             "tag": "?",
                             "color": "#3498DB",
                             "strikethrough": false,
-                            "backgroundColor": "transparent"
+                            "backgroundColor": "transparent",
+                            "bold": false,
+                            "italic": false,
+                            "underline": false
                         },
                         {
                             "tag": "//",
                             "color": "#474747",
                             "strikethrough": true,
-                            "backgroundColor": "transparent"
+                            "backgroundColor": "transparent",
+                            "bold": false,
+                            "italic": false,
+                            "underline": false
                         },
                         {
                             "tag": "todo",
                             "color": "#FF8C00",
                             "strikethrough": false,
-                            "backgroundColor": "transparent"
+                            "backgroundColor": "transparent",
+                            "bold": false,
+                            "italic": false,
+                            "underline": false
                         },
                         {
                             "tag": "*",
                             "color": "#98C379",
                             "strikethrough": false,
-                            "backgroundColor": "transparent"
+                            "backgroundColor": "transparent",
+                            "bold": false,
+                            "italic": false,
+                            "underline": false
                         }
                     ]
                 }

--- a/package.json
+++ b/package.json
@@ -140,46 +140,46 @@
                             "tag": "!",
                             "color": "#FF2D00",
                             "strikethrough": false,
+                            "underline": false,
                             "backgroundColor": "transparent",
                             "bold": false,
-                            "italic": false,
-                            "underline": false
+                            "italic": false
                         },
                         {
                             "tag": "?",
                             "color": "#3498DB",
                             "strikethrough": false,
+                            "underline": false,
                             "backgroundColor": "transparent",
                             "bold": false,
-                            "italic": false,
-                            "underline": false
+                            "italic": false
                         },
                         {
                             "tag": "//",
                             "color": "#474747",
                             "strikethrough": true,
+                            "underline": false,
                             "backgroundColor": "transparent",
                             "bold": false,
-                            "italic": false,
-                            "underline": false
+                            "italic": false
                         },
                         {
                             "tag": "todo",
                             "color": "#FF8C00",
                             "strikethrough": false,
+                            "underline": false,
                             "backgroundColor": "transparent",
                             "bold": false,
-                            "italic": false,
-                            "underline": false
+                            "italic": false
                         },
                         {
                             "tag": "*",
                             "color": "#98C379",
                             "strikethrough": false,
+                            "underline": false,
                             "backgroundColor": "transparent",
                             "bold": false,
-                            "italic": false,
-                            "underline": false
+                            "italic": false
                         }
                     ]
                 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -422,9 +422,13 @@ export class Parser {
 			}
 			
 			if(item.bold) {
+				// @ts-ignore - this feature is only available in last version of vscode and not in the npm package
+				// ts can find them in @types/vscode but unfortunately, the whole extension compilation fails when using @types/vscode
 				options.fontWeight = "bold";
 			}
 			if(item.italic) {
+				// @ts-ignore - this feature is only available in last version of vscode and not in the npm package
+				// ts can find them in @types/vscode but unfortunately, the whole extension compilation fails when using @types/vscode
 				options.fontStyle = "italic";
 			}
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -15,6 +15,9 @@ interface Contributions {
 		tag: string;
 		color: string;
 		strikethrough: boolean;
+		underline: boolean;
+		bold: boolean;
+		italic: boolean;
 		backgroundColor: string;
 	}];
 }
@@ -414,6 +417,15 @@ export class Parser {
 			let options: vscode.DecorationRenderOptions = { color: item.color, backgroundColor: item.backgroundColor };
 			if (item.strikethrough) {
 				options.textDecoration = "line-through";
+			} else if (item.underline) {
+				options.textDecoration = "underline";
+			}
+			
+			if(item.bold) {
+				options.fontWeight = "bold";
+			}
+			if(item.italic) {
+				options.fontStyle = "italic";
 			}
 
 			let escapedSequence = item.tag.replace(/([()[{*+.$^\\|?])/g, '\\$1');


### PR DESCRIPTION
### FIX CI -> Stack overflow is our best friend -> [link to the fix](https://stackoverflow.com/questions/55674746/travis-sh-0-cant-open-etc-init-d-xvfb)

### New features in response to #50
- add them as boolean
- fontWeight not added because fontWeight accepts a string while the css doc await for a number. I don't want to include misleading options (property could be "bold", "700" but not 700) , better to keep a boolean than introduce complicated usage.
- fontFamily and fontSize not availables in VSCode doc