### PR TITLE
Adding Batch and Command files support

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -399,6 +399,12 @@ export class Parser {
 				this.setCommentFormat("<!---", "<!---", "--->");
 				break;
 
+			case "bat":
+			case "cmd":
+				// you can use :: , rem or : with leading space to comment a line
+				this.delimiter = this.escapeRegExp('rem\ |::|: \ '); 
+				break;
+
 			case "plaintext":
 				this.isPlainText = true;
 


### PR DESCRIPTION
batch files and command files use a similar method tho comment a line
just use `rem COMMENT` or `::COMMENT` or `: COMMENT`
all of these are single line
there is no multi line comment in these files