### PR TITLE
Add fixme tag to support

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,6 +176,15 @@
                             "italic": false
                         },
                         {
+                            "tag": "fixme",
+                            "color": "#FF6000",
+                            "strikethrough": false,
+                            "underline": false,
+                            "backgroundColor": "transparent",
+                            "bold": true,
+                            "italic": false
+                        },
+                        {
                             "tag": "*",
                             "color": "#98C379",
                             "strikethrough": false,


### PR DESCRIPTION
like jetbrains IDE series (androidStudio, intellijIDea, webstorm , ...) tag
fixme has more priority than todo, so I set its color to more reddish and also set it default style to bold