### PR TITLE
Add TLA+ and PlusCal support

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ The default 5 can be modified to change the colors, and more can be added.
 * Pig
 * PlantUML
 * PL/SQL
+* PlusCal
 * PowerShell
 * Puppet
 * Python
@@ -150,6 +151,7 @@ The default 5 can be modified to change the colors, and more can be added.
 * Swift
 * Tcl
 * Terraform
+* TLA<sup>+</sup>
 * Twig
 * TypeScript
 * TypeScript React

--- a/package.json
+++ b/package.json
@@ -101,6 +101,8 @@
         "onLanguage:swift",
         "onLanguage:tcl",
         "onLanguage:terraform",
+        "onLanguage:tlaplus",
+        "onLanguage:tlaplus_cfg",
         "onLanguage:twig",
         "onLanguage:typescript",
         "onLanguage:typescriptreact",

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -191,7 +191,8 @@ export class Parser {
 
 		// Combine custom delimiters and the rest of the comment block matcher
 		let commentMatchString = "(^)+([ \\t]*\\*[ \\t]*)("; // Highlight after leading *
-		let regEx = /(^|[ \t])(\/\*\*)+([\s\S]*?)(\*\/)/gm; // Find rows of comments matching pattern /** */
+		let blockMatchString = `(^|[ \\t])(${this.blockCommentStart}\\*)+([\\s\\S]*?)${this.blockCommentEnd}`;
+		let regEx = new RegExp(blockMatchString, "gm"); // Find rows of comments matching pattern /** */
 
 		commentMatchString += characters.join("|");
 		commentMatchString += ")([ ]*|[:])+([^*/][^\\r\\n]*)";
@@ -399,6 +400,12 @@ export class Parser {
 				this.setCommentFormat("<!---", "<!---", "--->");
 				break;
 
+			case "tlaplus":
+			case "tlaplus_cfg":
+				this.setCommentFormat("\\*", "(*", "*)");
+				this.highlightJSDoc = true;
+				break;
+
 			case "plaintext":
 				this.isPlainText = true;
 
@@ -455,7 +462,7 @@ export class Parser {
 	 * @returns {string} The escaped string
 	 */
 	private escapeRegExp(input: string): string {
-		return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+		return input.replace(/[.*+?^${}()/|[\]\\]/g, '\\$&'); // $& means the whole matched string
 	}
 
 	/**

--- a/src/test/samples/tlaplus.tla
+++ b/src/test/samples/tlaplus.tla
@@ -1,0 +1,44 @@
+(*--algorithm tlaplus
+(**
+ * Example of a block comment inside PlusCal algorithm
+ * ! Alert
+ * ? Question
+ * * Highlight
+ * TODO Some stuff
+ *)
+begin
+    \* * Line comments also work
+    \* ? Do they?
+    \* ! They really do
+    skip;
+end algorithm; *)
+\* BEGIN TRANSLATION - the hash of the PCal code: PCal-57736ac5c15edfbcebd7f2832422e595
+VARIABLE pc
+
+(**
+ * Example of a block comment inside TLA+
+ * ! Alert
+ * ? Question
+ * * Highlight
+ * TODO Some stuff
+ *)
+
+vars == << pc >>
+
+Init == /\ pc = "Lbl_1"
+
+Lbl_1 == /\ pc = "Lbl_1"
+         /\ TRUE
+         /\ pc' = "Done"
+
+(* Allow infinite stuttering to prevent deadlock on termination. *)
+Terminating == pc = "Done" /\ UNCHANGED vars
+
+Next == Lbl_1
+           \/ Terminating
+
+Spec == Init /\ [][Next]_vars
+
+Termination == <>(pc = "Done")
+
+\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-c42acd1a2a013bcd259342cfe120880f


### PR DESCRIPTION
This PR adds support for the TLA<sup>+</sup> formal specification language and its satellite PlusCal language.
