### PR TITLE
feat: Add Protobuf support

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,3 +158,4 @@ The default 5 can be modified to change the colors, and more can be added.
 * Vue.js
 * XML
 * YAML
+* Protobuf

--- a/package.json
+++ b/package.json
@@ -108,7 +108,8 @@
         "onLanguage:verilog",
         "onLanguage:vue",
         "onLanguage:xml",
-        "onLanguage:yaml"
+        "onLanguage:yaml",
+        "onLanguage:proto3"
     ],
     "galleryBanner": {
         "color": "#e3f4ff",

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -285,6 +285,7 @@ export class Parser {
 			case "swift":
 			case "verilog":
 			case "vue":
+			case "proto3":
 				this.setCommentFormat("//", "/*", "*/");
 				break;
 			

--- a/src/test/samples/proto3.proto
+++ b/src/test/samples/proto3.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package sample;
+
+/**
+ * My Function
+ * ! Some Alert
+ * TODO Some stuff
+ * ?  Questions
+ * * Highlights
+ */
+message SampleMessage {
+    string hello = 1;
+}


### PR DESCRIPTION
Thank you for this awesome library!

This pull request adds support for Protobuf. As stated in [Google's Language Guide](https://developers.google.com/protocol-buffers/docs/proto3#adding_comments), comments use C/C++ syntax, therefore this change only adds the identifier `proto3` to the same block as mentioned languages.