### PR TITLE
Added support for Qlik script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "better-comments",
-    "version": "2.0.5",
+    "version": "2.1.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
         "onLanguage:powershell",
         "onLanguage:puppet",
         "onLanguage:python",
+        "onLanguage:qlik",
         "onLanguage:r",
         "onLanguage:racket",
         "onLanguage:ruby",

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -399,6 +399,10 @@ export class Parser {
 				this.setCommentFormat("<!---", "<!---", "--->");
 				break;
 
+			case "qlik":
+				this.setCommentFormat("//", "/*", "*/");
+				break;
+	
 			case "plaintext":
 				this.isPlainText = true;
 


### PR DESCRIPTION
I made a minor change, adding support for Qlik script .
Qlik Sense (and the older OlikView product) are data visualization/business intelligence tools with its own scripting dialect. 
Quite powerful, it's like a mix of SQL, VBScript and maybe some other scripting variants.
Anyways - would be nice to have Better Comments also in qlik script files (which are usually .qvs).

Cheers!