### PR TITLE
feat: Add Elm comments in documentation format

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -341,6 +341,8 @@ export class Parser {
 				break;
 
 			case "elm":
+				this.setCommentFormat("--", "{-\|?", "-}");
+				break;
 			case "haskell":
 				this.setCommentFormat("--", "{-", "-}");
 				break;

--- a/src/test/samples/elm.elm
+++ b/src/test/samples/elm.elm
@@ -26,7 +26,7 @@ tom = {firstName = "tom", lastName = "john", age = 34, status = Visitor }
 main =
     text "Hello world!"
 
-{-
+{-|
     TODO tab TODO
         !double tab
             ?triple tab


### PR DESCRIPTION
Next to the Haskell-syntax, elm has a special format for documentation,
that is currently not implemented:

  {-| Special comment type ...

  -}

Ref: https://package.elm-lang.org/help/documentation-format
