### PR TITLE
Add gleam example

### DIFF
--- a/src/test/samples/gleam.gleam
+++ b/src/test/samples/gleam.gleam
@@ -11,5 +11,5 @@ fn myFun () {
 // ! this is an alert
 // ? this is a question
 // * this is a highlight
-//// this code has been removed
+// // this code has been removed
 // todo clean up removed code

--- a/src/test/samples/gleam.gleam
+++ b/src/test/samples/gleam.gleam
@@ -1,0 +1,15 @@
+//// My module documentation at the head of a module file
+////
+
+/// My function documentation
+///
+fn myFun () {
+  Nil
+}
+
+// this is a comment
+// ! this is an alert
+// ? this is a question
+// * this is a highlight
+//// this code has been removed
+// todo clean up removed code


### PR DESCRIPTION
better comments is mostly working for gleam out of the box except for module documents which start with each line prefixed with `////`.

Do you have some pointers where to start contributing to this extension to fix this? All languages branch? How can I add multiple single line comments tags?:


`////` Gleam module documentation line
`///` Gleam documentation line
`//` Regular gleam comment line
