### PR TITLE
add type validation and some brief descriptions for better-comments.tags (configuration of the extension)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,17 +8,19 @@
             "name": "better-comments",
             "version": "3.0.0",
             "license": "SEE LICENSE IN LICENSE.md",
+            "dependencies": {
+                "json5": "^2.2.1"
+            },
             "devDependencies": {
                 "@types/json5": "^2.2.0",
                 "@types/node": "^17.0.23",
                 "@types/vscode": "^1.65.0",
-                "json5": "^2.2.1",
                 "tslint": "^6.1.3",
                 "typescript": "^4.6.3",
                 "vsce": "^2.7.0"
             },
             "engines": {
-                "vscode": "^1.47.0"
+                "vscode": "^1.65.0"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -786,7 +788,6 @@
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
             "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
-            "dev": true,
             "bin": {
                 "json5": "lib/cli.js"
             },
@@ -2237,8 +2238,7 @@
         "json5": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-            "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
-            "dev": true
+            "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA=="
         },
         "keytar": {
             "version": "7.9.0",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
                                     },
                                     {
                                         "type": "string",
-                                        "pattern": "#[0-9A-Z]{6}"
+                                        "pattern": "#[0-9a-zA-Z]{6}"
                                     }
                                 ]
                             },

--- a/package.json
+++ b/package.json
@@ -56,6 +56,68 @@
                 "better-comments.tags": {
                     "type": "array",
                     "description": "Tags which are used to color the comments. Changes require a restart of VS Code to take effect",
+                    "items": {
+                        "type": "object",
+                        "required": [
+                            "tag",
+                            "color",
+                            "backgroundColor"
+                        ],
+                        "properties": {
+                            "tag": {
+                                "type": "string"
+                            },
+                            "color": {
+                                "markdownDescription": "the color of comment. must be set either css color name or hex style like `\"color\": \"#3498DB\"`.",
+                                "anyOf": [
+                                    {
+                                        "enum": [
+                                            "AliceBlue", "AntiqueWhite", "Aqua", "Aquamarine", "Azure", "Beige", "Bisque", "Black", "BlanchedAlmond", "Blue", "BlueViolet", "Brown", "BurlyWood", "CadetBlue", "Chartreuse", "Chocolate", "Coral", "CornflowerBlue", "Cornsilk", "Crimson", "Cyan", "DarkBlue", "DarkCyan", "DarkGoldenRod", "DarkGray", "DarkGreen", "DarkKhaki", "DarkMagenta", "DarkOliveGreen", "Darkorange", "DarkOrchid", "DarkRed", "DarkSalmon", "DarkSeaGreen", "DarkSlateBlue", "DarkSlateGray", "DarkTurquoise", "DarkViolet", "DeepPink", "DeepSkyBlue", "DimGray", "DodgerBlue", "FireBrick", "FloralWhite", "ForestGreen", "Fuchsia", "Gainsboro", "GhostWhite", "Gold", "GoldenRod", "Gray", "Green", "GreenYellow", "HoneyDew", "HotPink", "IndianRed", "Indigo", "Ivory", "Khaki", "Lavender", "LavenderBlush", "LawnGreen", "LemonChiffon", "LightBlue", "LightCoral", "LightCyan", "LightGoldenRodYellow", "LightGrey", "LightGreen", "LightPink", "LightSalmon", "LightSeaGreen", "LightSkyBlue", "LightSlateGray", "LightSteelBlue", "LightYellow", "Lime", "LimeGreen", "Linen", "Magenta", "Maroon", "MediumAquaMarine", "MediumBlue", "MediumOrchid", "MediumPurple", "MediumSeaGreen", "MediumSlateBlue", "MediumSpringGreen", "MediumTurquoise", "MediumVioletRed", "MidnightBlue", "MintCream", "MistyRose", "Moccasin", "NavajoWhite", "Navy", "OldLace", "Olive", "OliveDrab", "Orange", "OrangeRed", "Orchid", "PaleGoldenRod", "PaleGreen", "PaleTurquoise", "PaleVioletRed", "PapayaWhip", "PeachPuff", "Peru", "Pink", "Plum", "PowderBlue", "Purple", "Red", "RosyBrown", "RoyalBlue", "SaddleBrown", "Salmon", "SandyBrown", "SeaGreen", "SeaShell", "Sienna", "Silver", "SkyBlue", "SlateBlue", "SlateGray", "Snow", "SpringGreen", "SteelBlue", "Tan", "Teal", "Thistle", "Tomato", "Turquoise", "Violet", "Wheat", "White", "WhiteSmoke", "Yellow", "YellowGreen"
+                                        ]
+                                    },
+                                    {
+                                        "type": "string",
+                                        "pattern": "#[0-9a-zA-Z]{6}"
+                                    }
+                                ]
+                            },
+                            "backgroundColor": {
+                                "markdownDescription": "the background color of comment line. must be set either css color name or hex style like `\"color\": \"transparent\"`.",
+                                "anyOf": [
+                                    {
+                                        "enum": [
+                                            "transparent"
+                                        ]
+                                    },
+                                    {
+                                        "enum": [
+                                            "AliceBlue", "AntiqueWhite", "Aqua", "Aquamarine", "Azure", "Beige", "Bisque", "Black", "BlanchedAlmond", "Blue", "BlueViolet", "Brown", "BurlyWood", "CadetBlue", "Chartreuse", "Chocolate", "Coral", "CornflowerBlue", "Cornsilk", "Crimson", "Cyan", "DarkBlue", "DarkCyan", "DarkGoldenRod", "DarkGray", "DarkGreen", "DarkKhaki", "DarkMagenta", "DarkOliveGreen", "Darkorange", "DarkOrchid", "DarkRed", "DarkSalmon", "DarkSeaGreen", "DarkSlateBlue", "DarkSlateGray", "DarkTurquoise", "DarkViolet", "DeepPink", "DeepSkyBlue", "DimGray", "DodgerBlue", "FireBrick", "FloralWhite", "ForestGreen", "Fuchsia", "Gainsboro", "GhostWhite", "Gold", "GoldenRod", "Gray", "Green", "GreenYellow", "HoneyDew", "HotPink", "IndianRed", "Indigo", "Ivory", "Khaki", "Lavender", "LavenderBlush", "LawnGreen", "LemonChiffon", "LightBlue", "LightCoral", "LightCyan", "LightGoldenRodYellow", "LightGrey", "LightGreen", "LightPink", "LightSalmon", "LightSeaGreen", "LightSkyBlue", "LightSlateGray", "LightSteelBlue", "LightYellow", "Lime", "LimeGreen", "Linen", "Magenta", "Maroon", "MediumAquaMarine", "MediumBlue", "MediumOrchid", "MediumPurple", "MediumSeaGreen", "MediumSlateBlue", "MediumSpringGreen", "MediumTurquoise", "MediumVioletRed", "MidnightBlue", "MintCream", "MistyRose", "Moccasin", "NavajoWhite", "Navy", "OldLace", "Olive", "OliveDrab", "Orange", "OrangeRed", "Orchid", "PaleGoldenRod", "PaleGreen", "PaleTurquoise", "PaleVioletRed", "PapayaWhip", "PeachPuff", "Peru", "Pink", "Plum", "PowderBlue", "Purple", "Red", "RosyBrown", "RoyalBlue", "SaddleBrown", "Salmon", "SandyBrown", "SeaGreen", "SeaShell", "Sienna", "Silver", "SkyBlue", "SlateBlue", "SlateGray", "Snow", "SpringGreen", "SteelBlue", "Tan", "Teal", "Thistle", "Tomato", "Turquoise", "Violet", "Wheat", "White", "WhiteSmoke", "Yellow", "YellowGreen"
+                                        ]
+                                    },
+                                    {
+                                        "type": "string",
+                                        "pattern": "#[0-9A-Z]{6}"
+                                    }
+                                ]
+                            },
+                            "strikethrough": {
+                                "type": "boolean",
+                                "default": false
+                            },
+                            "underline": {
+                                "type": "boolean",
+                                "default": false
+                            },
+                            "bold": {
+                                "type": "boolean",
+                                "default": false
+                            },
+                            "italic": {
+                                "type": "boolean",
+                                "default": false
+                            }
+                        }
+                    },
                     "default": [
                         {
                             "tag": "!",


### PR DESCRIPTION
Hello, the extension better-comments is really useful and I have used it for 2 years! Thanks!!

This PR includes JSON schema and some brief descriptions for configurations of `better-comments.tags`.
This PR will allow users to more easily review and customize the settings of tags!

In the schema, the properties required are `tag`, `color`, and `backgroundColor`  because these properties seem essential in the source code. If not correct, I will modify it.