### PR TITLE
Fixes #415 - Not working on remote workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
         "vscode": "^1.65.0"
     },
     "extensionKind": [
-        "ui",
-        "workspace"
+        "workspace",
+        "ui"
     ],
     "activationEvents": [
         "onStartupFinished"


### PR DESCRIPTION
According to https://code.visualstudio.com/api/advanced-topics/extension-host#preferred-extension-location, the order of `[ "workspace", "ui" ]` will allow this extension to work in remote workspaces.

Reversed the order as it appears in `package.json` and tested it with as remote, the extension will now properly highlight comments as designed in WSL.