### PR TITLE
Fixed block comments

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -124,14 +124,18 @@ export class Parser {
         }
 
         // Combine custom delimiters and the rest of the comment block matcher
-        let commentMatchString = "(^)+([ \\t]*[ \\t]*)(";
+        let commentMatchString = "(^)([ \\t]*)("
+        commentMatchString += this.blockCommentStart;
+        commentMatchString += ")?([ \\t]*)(";
         commentMatchString += characters.join("|");
-        commentMatchString += ")([ ]*|[:])+([^*/][^\\r\\n]*)";
+        commentMatchString += ")([^\\r\\n]*)(("
+        commentMatchString += this.blockCommentEnd
+        commentMatchString += ")|[\\n\\r])";
 
         // Use start and end delimiters to find block comments
         let regexString = "(^|[ \\t])(";
         regexString += this.blockCommentStart;
-        regexString += "[\\s])+([\\s\\S]*?)(";
+        regexString += "[^*][\\s]?)([\\s\\S]*?)(";
         regexString += this.blockCommentEnd;
         regexString += ")";
 
@@ -151,7 +155,7 @@ export class Parser {
                 let range: vscode.DecorationOptions = { range: new vscode.Range(startPos, endPos) };
 
                 // Find which custom delimiter was used in order to add it to the collection
-                let matchString = line[3] as string;
+                let matchString = line[5] as string;
                 let matchTag = this.tags.find(item => item.tag.toLowerCase() === matchString.toLowerCase());
 
                 if (matchTag) {


### PR DESCRIPTION
# Fixes #456 by rewriting regular expressions for block comments.

## Known Bugs:
Whitespace directly before a block comment is required(as it was before). This was maintained to make it harder to accidentally create "ghost" blocks, where an open tag occurs within an inline comment, causing future lines to appear styled when they shouldn't. This bug is still easily recreatable by typing ```// /*``` but is unlikely to affect many users in it's current state.

## Additional Considerations:
An attempt was made to keep the code as similar as possible to the original, as well as keep consistency with inline comments. As such, the openings of block comments are styled with the first tag, if one occurs on the same line as the opening.

A star(\*) immediately following the commentBlockStart will not be considered a multiline comment for the sake of later parsing JSdoc comments, so my patches don't apply to any  comment that starts with a star(\*).

I have tested this patch with JavaScript, HTML, and Python, but a more thorough testing with other languages is both welcome and encouraged.
