### PR TITLE
Fixed regex bug in parser.SetRegex

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "better-comments",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "better-comments",
-            "version": "3.0.1",
+            "version": "3.0.2",
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "json5": "^2.2.1"

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -68,7 +68,7 @@ export class Parser {
         // Apply all configurable comment start tags
         this.expression += "(";
         this.expression += characters.join("|");
-        this.expression += ")+(.*)";
+        this.expression += ")(.*)";
     }
 
     /**


### PR DESCRIPTION
This is a duplicate of #455 in order to change the name of the branch being merged from. Nothing else has changed between the two PRs

Fixes https://github.com/aaron-bond/better-comments/issues/454 by removing the erroneous plus in the inline comment regex.